### PR TITLE
Fix CSS rule removal after using highlight option

### DIFF
--- a/src/utils/highlighter-overlays.ts
+++ b/src/utils/highlighter-overlays.ts
@@ -439,4 +439,5 @@ export function removeExistingHighlights() {
 	if (existingHighlights.length > 0) {
 		existingHighlights.forEach(el => el.remove());
 	}
+	document.body.classList.remove('overflowHidden');
 }

--- a/src/utils/highlighter.ts
+++ b/src/utils/highlighter.ts
@@ -93,6 +93,7 @@ export function toggleHighlighterMenu(isActive: boolean) {
 		if (!generalSettings.alwaysShowHighlights) {
 			removeExistingHighlights();
 		}
+		document.body.classList.remove('overflowHidden');
 	}
 	updateHighlightListeners();
 }
@@ -667,6 +668,7 @@ export function clearHighlights() {
 			notifyHighlightsUpdated();
 			updateHighlighterMenu();
 			addToHistory('remove', oldHighlights, []);
+			document.body.classList.remove('overflowHidden'); // Remove overflowHidden class
 		});
 	});
 }


### PR DESCRIPTION
Remove the `.overflowHidden` CSS rule from the web page styles after using the highlight option.

* **Highlighter Menu**: Add logic to `toggleHighlighterMenu` function in `src/utils/highlighter.ts` to remove `.overflowHidden` class when highlighter mode is turned off.
* **Clear Highlights**: Add logic to `clearHighlights` function in `src/utils/highlighter.ts` to remove `.overflowHidden` class when highlights are cleared.
* **Remove Existing Highlights**: Add logic to `removeExistingHighlights` function in `src/utils/highlighter-overlays.ts` to remove `.overflowHidden` class when highlights are removed.

